### PR TITLE
Add Macbook Pro 9,1 (Mid 2012, Non-Retina) to tested hardware

### DIFF
--- a/gpu-switch
+++ b/gpu-switch
@@ -20,6 +20,7 @@ Arguments:
   -h, --help
 
 Tested hardware:
+  MacBook Pro 9,1  (Mid 2012, Non-Retina)
   Macbook Pro 10,1 (Mid 2012, Retina)
   Macbook Pro 11,3 (Late 2013, Retina)
 EOF


### PR DESCRIPTION
As requested, I've tested this on the MBP 9,1 -- successfullly. Found that nouveau does not switch the DDC lines though, consequently does not recognize the panel. Will look into this separately. In other news, patch for switching on AUXCH access is ready, will mail it in a bit.
