### PR TITLE
Add Macbook Pro 8,2 (Late 2011, Non-Retina) to tested hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ or
 Otherwise will end up with a powered down integrated graphics card and a **black screen**.
 
 ##Tested Hardware:
-- Macbook Pro 10,1 (Mid 2012, Retina)
+- Macbook Pro 8,2  (Late 2011, Non-Retina)
+- Macbook Pro 9,1  (Mid  2012, Non-Retina)
+- Macbook Pro 10,1 (Mid  2012, Retina)
 - Macbook Pro 11,3 (Late 2013, Retina) 
 
 ## Future Work:

--- a/gpu-switch
+++ b/gpu-switch
@@ -20,8 +20,9 @@ Arguments:
   -h, --help
 
 Tested hardware:
-  MacBook Pro 9,1  (Mid 2012, Non-Retina)
-  Macbook Pro 10,1 (Mid 2012, Retina)
+  MacBook Pro 8,2  (Late 2011, Non-Retina)
+  MacBook Pro 9,1  (Mid  2012, Non-Retina)
+  Macbook Pro 10,1 (Mid  2012, Retina)
   Macbook Pro 11,3 (Late 2013, Retina)
 EOF
 }


### PR DESCRIPTION
Tested-by: William Brown william@blackhats.net.au (@firstyear)
