### PR TITLE
Add MacBook Pro 5,3 (Mid 2009) to tested hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ or
 Otherwise will end up with a powered down integrated graphics card and a **black screen**.
 
 ##Tested Hardware:
+- Macbook Pro 5,3  (Mid  2009, Non-Retina)
 - Macbook Pro 8,2  (Late 2011, Non-Retina)
 - Macbook Pro 9,1  (Mid  2012, Non-Retina)
 - Macbook Pro 10,1 (Mid  2012, Retina)

--- a/gpu-switch
+++ b/gpu-switch
@@ -20,6 +20,7 @@ Arguments:
   -h, --help
 
 Tested hardware:
+  MacBook Pro 5,3  (Mid  2009, Non-Retina)
   MacBook Pro 8,2  (Late 2011, Non-Retina)
   MacBook Pro 9,1  (Mid  2012, Non-Retina)
   Macbook Pro 10,1 (Mid  2012, Retina)


### PR DESCRIPTION
The script also works on my MacBook Pro 5,3, which has a dual Nvidia configuration: an integrated 9400M and a discrete 9600M GT.
