### PR TITLE
Linux 4.5 compat: efivarfs entries immutable by default

### DIFF
--- a/gpu-switch
+++ b/gpu-switch
@@ -41,6 +41,7 @@ switch_gpu(){
       exit 1
     fi
   fi
+  chattr -i "${sysfs_efi_vars}/${efi_gpu}" 2> /dev/null
   printf "\x07\x00\x00\x00\x${1}\x00\x00\x00" > "${sysfs_efi_vars}/${efi_gpu}" 
 }
 


### PR DESCRIPTION
Fix regression introduced by torvalds/linux@ed8b0de5a33d ("efi: Make efivarfs entries immutable by default").

chattr fails on pre-4.5 kernels or if the gpu-power-prefs entry is missing (e.g. after booting into OS X). My initial version checked the kernel release and existence of the file but then I settled on this one liner which just calls chattr unconditionally and pipes any error messages to /dev/null.
